### PR TITLE
Update GenAI.DirectML to version 0.3.0

### DIFF
--- a/PDFAnalyzer/PDFAnalyzer.csproj
+++ b/PDFAnalyzer/PDFAnalyzer.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="BERTTokenizers" Version="1.2.0" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.18.0" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.2.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntimeGenAI.DirectML" Version="0.3.0" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.106">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Version 0.2.0 of Microsoft.ML.OnnxRuntimeGenAI.DirectML did not contain a arm64 version meaning it could not run on a copilot+ pc. Version 0.3.0 fixes that issue.